### PR TITLE
Append, rather than reassign, posts to list

### DIFF
--- a/IBGPostsSwift/UI/View Controllers/PostsTableViewController.swift
+++ b/IBGPostsSwift/UI/View Controllers/PostsTableViewController.swift
@@ -82,16 +82,17 @@ class PostsTableViewController: UITableViewController {
                 }
                 OperationQueue.main.addOperation({
                     self.updateUIForNetworkCallEnd()
+                    
                 })
                 return
             }
             
             if (self.isRefreshing) {
-                self.postsArray.removeAll()
                 self.isRefreshing = false
             }
             
-            self.postsArray = posts
+            self.postsArray += posts
+            
             OperationQueue.main.addOperation({
                 self.tableView.reloadData()
                 self.updateForNetworkCallEnd()


### PR DESCRIPTION
+ We demonstrate loading with the same list of posts each time, so we need to copy that same list to the end of the existing list with each refresh